### PR TITLE
Fix bug with some providers returning empty strings as tokens

### DIFF
--- a/streaming-chat/src/main/java/io/openliberty/sample/langchain4j/StreamingChatService.java
+++ b/streaming-chat/src/main/java/io/openliberty/sample/langchain4j/StreamingChatService.java
@@ -52,6 +52,7 @@ public class StreamingChatService {
         try {
             String sessionId = session.getId();
             switch (agent.streamingChat(sessionId, message, token -> {
+                if (token.equals("")) return;
                 remote.sendText(token);
                 Thread.sleep(100);
             })) {


### PR DESCRIPTION
With GitHub Models and gpt-4o-mini, the first token is sometimes an empty string. The unit test breaks since the empty string denotes the end of the message, thus checking if an empty string contains a year.