### PR TITLE
Fix test to work on Ollama

### DIFF
--- a/streaming-chat/src/test/java/it/io/openliberty/sample/langchain4j/StreamingChatServiceIT.java
+++ b/streaming-chat/src/test/java/it/io/openliberty/sample/langchain4j/StreamingChatServiceIT.java
@@ -34,7 +34,7 @@ public class StreamingChatServiceIT {
         StreamingChatClient client = new StreamingChatClient(uri);
         future = new CompletableFuture<>();
         builder = new StringBuilder();
-        client.sendMessage("When was the LangChain4j launched?");
+        client.sendMessage("LangChain4j is a Java framework launched in 2023 to connect to AI model providers. When was LangChain4j launched?");
         String message;
         try {
             message = future.get(20, TimeUnit.SECONDS);
@@ -43,9 +43,7 @@ public class StreamingChatServiceIT {
         }
         client.close();
         assertNotNull(message);
-        assertTrue(message.contains("2020") || message.contains("2021") ||
-            message.contains("2022") || message.contains("2023"),
-            message);
+        assertTrue(message.contains("2023"), message);
     }
 
     public static void verify(String message) {

--- a/streaming-chat/src/test/java/it/io/openliberty/sample/langchain4j/StreamingChatServiceIT.java
+++ b/streaming-chat/src/test/java/it/io/openliberty/sample/langchain4j/StreamingChatServiceIT.java
@@ -34,7 +34,7 @@ public class StreamingChatServiceIT {
         StreamingChatClient client = new StreamingChatClient(uri);
         future = new CompletableFuture<>();
         builder = new StringBuilder();
-        client.sendMessage("LangChain4j is a Java framework launched in 2023 to connect to AI model providers. When was LangChain4j launched?");
+        client.sendMessage("What are large language models?");
         String message;
         try {
             message = future.get(20, TimeUnit.SECONDS);
@@ -43,7 +43,7 @@ public class StreamingChatServiceIT {
         }
         client.close();
         assertNotNull(message);
-        assertTrue(message.contains("2023"), message);
+        assertTrue(message.contains("artificial intelligence"), message);
     }
 
     public static void verify(String message) {


### PR DESCRIPTION
Closes GH-73

Specify the year that LangChain4j was created. Should be fine since we are testing the streaming functionality, not the model's knowledge.