### PR TITLE
disable log4j warnings

### DIFF
--- a/rag-db/pom.xml
+++ b/rag-db/pom.xml
@@ -53,14 +53,14 @@
             <version>1.7.1</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-reload4j</artifactId>
-            <version>2.0.17</version>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
+            <version>1.7.1-beta14</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-document-parser-apache-tika</artifactId>
+            <version>1.7.1-beta14</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
@@ -88,6 +88,27 @@
             <artifactId>com.ibm.websphere.appserver.api.ssl</artifactId>
             <version>1.8.105</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
+            <version>2.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>10.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+            <version>0.26.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -118,32 +139,6 @@
             <artifactId>websocket-jakarta-client</artifactId>
             <version>11.0.26</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.websocket</groupId>
-            <artifactId>jakarta.websocket-api</artifactId>
-            <version>2.2.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
-            <version>1.7.1-beta14</version>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-document-parser-apache-tika</artifactId>
-            <version>1.7.1-beta14</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-core</artifactId>
-            <version>10.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.commonmark</groupId>
-            <artifactId>commonmark</artifactId>
-            <version>0.26.0</version>
         </dependency>
     </dependencies>
 

--- a/rag-db/src/main/resources/simplelogger.properties
+++ b/rag-db/src/main/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=off


### PR DESCRIPTION
Remove the following warnings
```
[INFO] [err] log4j:WARN No appenders could be found for logger (org.mongodb.driver.cluster).
[INFO] [err] log4j:WARN Please initialize the log4j system properly.
[INFO] [err] log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
```